### PR TITLE
Initial action: validate XML files for well-formedness

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 /.remarkrc               export-ignore
 /.yamllint.yml           export-ignore
 /.github/                export-ignore
+/tests/                  export-ignore
 
 #
 # Auto detect text files and perform LF normalization

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,3 +26,67 @@ jobs:
   remark:
     name: 'QA Markdown'
     uses: PHPCSStandards/.github/.github/workflows/reusable-remark.yml@main
+
+  test:
+    needs: yamllint
+
+    name: "${{ matrix.name }}"
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          ####################################################
+          # Basic action input handling.
+          ####################################################
+
+          # Test input handling: missing required input.
+          - name: "Test required input missing"
+            expected: "fail"
+
+          ####################################################
+          # Basic well-formedness tests.
+          ####################################################
+
+          # Test basic well-formedness validation.
+          - name: "Test no XSD, valid XML"
+            pattern: tests/fixtures/valid-basic.xml
+            expected: success
+
+          - name: "Test no XSD, invalid XML"
+            pattern: tests/fixtures/invalid-basic.xml
+            expected: fail
+
+          # Test that glob patterns are handled correctly.
+          - name: "Test no XSD, glob, valid XML files"
+            pattern: ./tests/fixtures/all-valid-basic/*.xml
+            expected: success
+
+          - name: "Test no XSD, glob, invalid XML files"
+            pattern: ./tests/*/some-valid-basic/*.xml
+            expected: fail
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run the test
+        id: xmllint-validate
+        continue-on-error: true
+        uses: ./
+        with:
+          pattern: ${{ matrix.pattern }}
+
+      - name: "Check the result of a successful test against expectation"
+        if: ${{ steps.xmllint-validate.outcome == 'success' }}
+        run: |
+          if [ "${{ matrix.expected == 'fail' }}" == "true" ]; then
+            exit 1
+          fi
+
+      - name: "Check the result of a failed test against expectation"
+        if: ${{ steps.xmllint-validate.outcome != 'success' }}
+        run: |
+          if [ "${{ matrix.expected == 'success' }}" == "true" ]; then
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -1,3 +1,57 @@
-# xmllint-validate
+# XMLLint Validate
 
-GitHub Action to validate an XML file for being well-formed and optionally validate against an XSD file
+GitHub Action to validate XML files for being well-formed.
+
+## Action inputs
+
+| Input     | Required | Type   | Notes                                                                                 |
+|-----------|----------|--------|---------------------------------------------------------------------------------------|
+| `pattern` | yes      | string | The file(s) to validate. The input expects a path to a single file or a glob pattern. |
+
+
+## Using the action
+
+Validating the well-formedness of a single XML file:
+```yaml
+jobs:
+  test:
+    name: "XMLLint validate"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate XML file
+        uses: phpcsstandards/xmllint-validate@v0
+        with:
+          pattern: "path/to/file.xml"
+```
+
+Glob patterns are also supported:
+```yaml
+jobs:
+  test:
+    name: "XMLLint validate"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate XML files
+        uses: phpcsstandards/xmllint-validate@v0
+        with:
+          pattern: "path/to/*/docs/*.xml"
+```
+
+
+## Contributing
+
+Contributions to this project are welcome. Clone this repository, create a new branch, make your changes, commit them and send in a pull request.
+
+If unsure whether the changes you are proposing would be welcome, open an issue first to discuss your proposal.
+
+
+## Copyright and License
+
+The phpcsstandards/xmllint-validate GitHub Action is ©copyright PHPCSStandards and contributors and licensed for use under the terms of the MIT License (MIT).
+Please see [LICENSE](LICENSE) for more information.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,46 @@
+# Actions docs: https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions
+# XMLLint docs: http://xmlsoft.org/xmllint.html
+
+name: 'XMLLint Validate'
+author: 'Juliette Reinders Folmer'
+description: >-
+  Validate an XML file for being well-formed.
+
+# Icons available: https://feathericons.com/
+branding:
+  icon: 'check-circle'
+  color: 'green'
+
+inputs:
+  pattern:
+    description: 'Path to the file or glob pattern for the file(s) to validate with xmllint.'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: 'Validate pattern input'
+      if: ${{ ! inputs.pattern }}
+      shell: bash
+      run: |
+        # Validate pattern input.
+        echo "::error title=XMLLint Validate::Missing required input 'pattern'. Please provide a path to a file or a glob pattern."
+        exit 1
+
+    # Updating the lists can fail intermittently, typically after Microsoft has released a new package.
+    # This should not be blocking for this action, so ignore any errors from this step.
+    # Ref: https://github.com/dotnet/core/issues/4167
+    - name: 'Update the available packages list'
+      continue-on-error: true
+      shell: bash
+      run: sudo apt-get -q update > /dev/null
+
+    - name: 'Install xmllint'
+      shell: bash
+      run: sudo apt-get -q install --no-install-recommends -y libxml2-utils > /dev/null
+
+    - name: 'Validate for well-formedness'
+      env:
+        GLOB_PATTERN: ${{ inputs.pattern }}
+      shell: bash
+      run: xmllint --noout $GLOB_PATTERN

--- a/tests/fixtures/all-valid-basic/A-good.xml
+++ b/tests/fixtures/all-valid-basic/A-good.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<toplevel title="Ten chars"/>
+

--- a/tests/fixtures/all-valid-basic/B-good.xml
+++ b/tests/fixtures/all-valid-basic/B-good.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset title="Ten chars">
+    <rule ref="ref"/>
+</ruleset>

--- a/tests/fixtures/all-valid-basic/C-good.xml
+++ b/tests/fixtures/all-valid-basic/C-good.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<mydoc>
+    <myelement>Some text</myelement>
+</mydoc>

--- a/tests/fixtures/invalid-basic.xml
+++ b/tests/fixtures/invalid-basic.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<toplevel>
+    <unclosedelement>
+</toplevel>

--- a/tests/fixtures/some-valid-basic/A-bad.xml
+++ b/tests/fixtures/some-valid-basic/A-bad.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<something>
+    <unmatched/>
+</else>

--- a/tests/fixtures/some-valid-basic/B-good.xml
+++ b/tests/fixtures/some-valid-basic/B-good.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset title="Ten chars">
+    <rule ref="ref"/>
+</ruleset>

--- a/tests/fixtures/some-valid-basic/C-bad.xml
+++ b/tests/fixtures/some-valid-basic/C-bad.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<toplevel>
+    <unclosedelement>
+</toplevel>

--- a/tests/fixtures/valid-basic.xml
+++ b/tests/fixtures/valid-basic.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<toplevel>
+    <closedelement/>
+</toplevel>


### PR DESCRIPTION
This commit sets up the initial action to allow for validating either a single file or a group of files identified via a glob pattern for well-formedness.

Includes tests.

Note:
* As per the [Metadata syntax documentation](https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#inputs): "Actions using required: true will not automatically return an error if the input is not specified.". Hence, the validation that the required input is actually provided.
* Also take note that the error message in the validation uses the special syntax for sending an error in GH Actions to allow it to be picked up by the API. Ref: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions?tool=bash#setting-an-error-message
* Includes lessons leant along the way in other GH Action workflows regarding intermittent errors which can be encountered with `apt-get update` as per  dotnet/core 4167
* An attempt is made to reduce the "noise" of the logs for the `apt-get` commands by piping their output to `dev/null`.
* Lastly, steps which are run in a composite action will be folded, with just the first line of a multi-line step showing. For non-single line steps, it is therefore good practice to have a comment on the first line annotating the purpose of the step. Hence the `# Validate pattern input.` comment.