### PR TITLE
Allow for validating against a remote XSD file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,55 @@ jobs:
             xsd-file: tests/fixtures/xsd-files/valid-local.xsd
             expected: "fail"
 
+          ####################################################
+          # Validate against an (originally) remote XSD file.
+          ####################################################
+
+          # Test input handling: optional XSD URL.
+          - name: "Test XSD URL wrong scheme"
+            pattern: tests/fixtures/valid-local.xml
+            xsd-url: file://tests/fixtures/valid-local.xml
+            expected: "fail"
+
+          - name: "Test XSD URL wrong file extension"
+            pattern: tests/fixtures/valid-remote.xml
+            xsd-url: https://phpcsstandards.github.io/xmllint-validate/test-fixtures/wrong-extension.notxsd
+            expected: "fail"
+
+          - name: "Test XSD URL doesn't exist"
+            pattern: tests/fixtures/valid-remote.xml
+            xsd-url: https://phpcsstandards.github.io/xmllint-validate/test-fixtures/file-does-not-exist.xsd
+            expected: "fail"
+
+          - name: "Test XSD URL empty"
+            pattern: tests/fixtures/valid-remote.xml
+            xsd-url: https://phpcsstandards.github.io/xmllint-validate/test-fixtures/file-is-empty.xsd
+            expected: "fail"
+
+          # Test validating against a (originally) remote XSD schema.
+          - name: "Test remote XSD file, valid XML"
+            pattern: tests/fixtures/valid-remote.xml
+            xsd-url: http://phpcsstandards.github.io/xmllint-validate/test-fixtures/valid-remote.xsd
+            expected: "success"
+
+          - name: "Test remote XSD file, valid XML, not valid against schema"
+            pattern: tests/fixtures/invalid-remote.xml
+            xsd-url: https://phpcsstandards.github.io/xmllint-validate/test-fixtures/valid-remote.xsd
+            expected: "fail"
+
+          # Safeguard that a local XSD file always takes precedence over a remote XSD URL.
+          - name: "Test local XSD overrules remote [1]"
+            pattern: tests/fixtures/valid-local.xml
+            xsd-file: tests/fixtures/xsd-files/valid-local.xsd
+            xsd-url: https://phpcsstandards.github.io/xmllint-validate/test-fixtures/valid-remote.xsd
+            expected: "success"
+
+          - name: "Test local XSD overrules remote [2]"
+            pattern: tests/fixtures/valid-remote.xml
+            xsd-file: tests/fixtures/xsd-files/valid-local.xsd
+            xsd-url: https://phpcsstandards.github.io/xmllint-validate/test-fixtures/valid-remote.xsd
+            expected: "fail"
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -124,6 +173,7 @@ jobs:
         with:
           pattern: ${{ matrix.pattern }}
           xsd-file: ${{ matrix.xsd-file }}
+          xsd-url: ${{ matrix.xsd-url }}
 
       - name: "Check the result of a successful test against expectation"
         if: ${{ steps.xmllint-validate.outcome == 'success' }}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ GitHub Action to validate XML files for being well-formed and optionally validat
 |------------|----------|--------|---------------------------------------------------------------------------------------|
 | `pattern`  | yes      | string | The file(s) to validate. The input expects a path to a single file or a glob pattern. |
 | `xsd-file` | no       | string | Path to a local file containing the XSD schema to validate against.                   |
+| `xsd-url`  | no       | string | URL to a remote file containing the XSD schema to validate against.                   |
 
+> [!NOTE]
+> If both an `xsd-file` and an `xsd-url` are passed, the `xsd-file` takes precedence.
 
 ## Using the action
 
@@ -59,6 +62,23 @@ jobs:
         with:
           pattern: "path/to/*/docs/*.xml"
           xsd-file: "path/to/docs.xsd"
+```
+
+Validating XML files against a remote XSD schema:
+```yaml
+jobs:
+  test:
+    name: "XMLLint validate"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate XML file
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "path/to/*/docs/*.xml"
+          xsd-url: "https://examples.org/docs.xsd"
 ```
 
 

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: 'Path to a local file containing the XSD schema to validate against.'
     required: false
     default: ''
+  xsd-url:
+    description: 'URL to a remote file containing the XSD schema to validate against.'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -55,6 +59,55 @@ runs:
           fi
         fi
 
+    - name: 'Notify about precedence'
+      if: ${{ inputs.xsd-file && inputs.xsd-url }}
+      shell: bash
+      # yamllint disable rule:line-length
+      run: |
+        echo "::warning title=XMLLint Validate::Both a local file as well as a remote URL passed for the XSD file. The local file takes precedence, the remote URL will be ignored."
+        # yamllint enable rule:line-length
+
+    - name: 'Set local file name'
+      if: ${{ ! inputs.xsd-file && inputs.xsd-url }}
+      shell: bash
+      run: |
+        # Set environment variable.
+        # Name which is unlikely to conflict with any existing files in a repo.
+        echo "DOWNLOADED_XSD_FILE=xmllint-validate-action-schema.xsd" >> "$GITHUB_ENV"
+
+    - name: 'Validate the URL and download the schema file'
+      id: valid_xsdurl
+      if: ${{ ! inputs.xsd-file && inputs.xsd-url }}
+      env:
+        XSD_URL: ${{ inputs.xsd-url }}
+      shell: bash
+      # yamllint disable rule:line-length
+      run: |
+        # Validate remote URL input and download file.
+        # Check for non-zero length URL input.
+        if [[ -n "${{ env.XSD_URL }}" ]]; then
+          # Check that URL uses http(s) protocol.
+          if [[ "${{ startsWith( env.XSD_URL, 'http://' ) || startsWith( env.XSD_URL, 'https://' ) || startsWith( env.XSD_URL, 'ftp://' ) }}" == "false" ]]; then
+            echo "::error title=XMLLint Validate::URL to the XSD file must be an 'http', 'https' or 'ftp' URL."
+            exit 1
+          # Check that URL ends on .xsd.
+          elif [[ "${{ endsWith( env.XSD_URL, '.xsd' ) }}" == "false" ]]; then
+            echo "::error title=XMLLint Validate::URL to the XSD file must point to a file using an '.xsd' file extension."
+            exit 1
+          # Try to download it.
+          else
+            wget -nc -nv "${{ env.XSD_URL }}" -O "${{ env.DOWNLOADED_XSD_FILE }}"
+            if [[ -f "${{ env.DOWNLOADED_XSD_FILE }}" && -s "${{ env.DOWNLOADED_XSD_FILE }}" ]]; then
+              echo 'Download of the XSD file succesfull.'
+              exit 0
+            else
+              echo "::error title=XMLLint Validate::Remote XSD file must exist and have a file size greater than 0."
+              exit 1
+            fi
+          fi
+        fi
+        # yamllint enable rule:line-length
+
     # Updating the lists can fail intermittently, typically after Microsoft has released a new package.
     # This should not be blocking for this action, so ignore any errors from this step.
     # Ref: https://github.com/dotnet/core/issues/4167
@@ -68,7 +121,7 @@ runs:
       run: sudo apt-get -q install --no-install-recommends -y libxml2-utils > /dev/null
 
     - name: 'Validate for well-formedness'
-      if: ${{ ! inputs.xsd-file }}
+      if: ${{ ! inputs.xsd-file && ! inputs.xsd-url }}
       env:
         GLOB_PATTERN: ${{ inputs.pattern }}
       shell: bash
@@ -81,3 +134,15 @@ runs:
         XSD_FILE: ${{ inputs.xsd-file }}
       shell: bash
       run: xmllint --noout --schema "$XSD_FILE" $GLOB_PATTERN
+
+    - name: 'Validate against downloaded remote schema'
+      if: ${{ ! inputs.xsd-file && inputs.xsd-url }}
+      env:
+        GLOB_PATTERN: ${{ inputs.pattern }}
+      shell: bash
+      run: xmllint --noout --schema ${{ env.DOWNLOADED_XSD_FILE }} $GLOB_PATTERN
+
+    - name: 'Clean up downloaded file'
+      if: ${{ ! inputs.xsd-file && inputs.xsd-url }}
+      shell: bash
+      run: rm -f ${{ env.DOWNLOADED_XSD_FILE }}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,8 @@
+# Test Documentation
+
+The tests for this action runner consist of three parts:
+1. The `.github/workflows/test.yml` workflow.
+2. "Local" test fixtures in the `tests/fixtures` directory.
+3. "Remote" tests fixtures in the `docs/tests/` directory.
+
+The `docs` directory is set up to be deployed to a GH Pages website on https://.... to ensure there are downloadable files for use in the tests.

--- a/tests/fixtures/invalid-remote.xml
+++ b/tests/fixtures/invalid-remote.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<remote title="Not 10 ch">
+    <wrongelement>This document is INvalid for the valid-remote.xsd file.</wrongelement>
+</remote>

--- a/tests/fixtures/valid-remote.xml
+++ b/tests/fixtures/valid-remote.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<remote title="This must be more than ten chars">
+    <subelement>This document is valid for the valid-remote.xsd file.</subelement>
+</remote>


### PR DESCRIPTION
This commit add a new input `xsd-url` which takes a URL for the XSD file. The workflow will attempt to download the XSD file and if succesful and the file identifies as a non-empty `xsd` file, the XML file(s) provided via the `pattern` input will be validated against the provided (remote) XSD file.

If both the `xsd-file` as well as the `xsd-url` inputs are provided, the local `xsd-file` will always take precedence over the (remote) `xsd-url`.

Includes tests.

---

Note: the "remote" XSD files used by these tests were set up & pulled via PR #4 and are deployed to a GH Pages website to allow for testing the functionality in this PR.