### PR TITLE
Allow for annotating violations in PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,6 +162,42 @@ jobs:
             xsd-url: https://phpcsstandards.github.io/xmllint-validate/test-fixtures/valid-remote.xsd
             expected: "fail"
 
+          ####################################################
+          # Support "Show in PR".
+          ####################################################
+
+          # The default behaviour (enabled, not explicitly passed) is tested via all the other tests.
+          # Even though we can't safeguard the underlying functionality via CI, it can be
+          # confirmed the toggle functionality works correctly by looking at the "Annotations" fold-out
+          # above the logs for the individual jobs which have a "fail" expectation.
+
+          # Safeguard that explicitly enabling/disabling the show-in-pr option doesn't break anything.
+          - name: "Test show-in-pr: bool true"
+            pattern: tests/fixtures/invalid-basic.xml
+            show-in-pr: true
+            expected: "fail"
+
+          - name: "Test show-in-pr: string true"
+            pattern: tests/fixtures/invalid-basic.xml
+            show-in-pr: 'true'
+            expected: "fail"
+
+          - name: "Test show-in-pr: bool false"
+            pattern: tests/fixtures/invalid-basic.xml
+            show-in-pr: false
+            expected: "fail"
+
+          - name: "Test show-in-pr: string false"
+            pattern: tests/fixtures/invalid-basic.xml
+            show-in-pr: 'false'
+            expected: "fail"
+
+          # Any other value should have no influence and the default behaviour (annotations = on) should prevail.
+          - name: "Test show-in-pr: unsupported value"
+            pattern: tests/fixtures/invalid-basic.xml
+            show-in-pr: somethingElse
+            expected: "fail"
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -174,6 +210,7 @@ jobs:
           pattern: ${{ matrix.pattern }}
           xsd-file: ${{ matrix.xsd-file }}
           xsd-url: ${{ matrix.xsd-url }}
+          show-in-pr: ${{ matrix.show-in-pr }}
 
       - name: "Check the result of a successful test against expectation"
         if: ${{ steps.xmllint-validate.outcome == 'success' }}

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ GitHub Action to validate XML files for being well-formed and optionally validat
 
 ## Action inputs
 
-| Input      | Required | Type   | Notes                                                                                 |
-|------------|----------|--------|---------------------------------------------------------------------------------------|
-| `pattern`  | yes      | string | The file(s) to validate. The input expects a path to a single file or a glob pattern. |
-| `xsd-file` | no       | string | Path to a local file containing the XSD schema to validate against.                   |
-| `xsd-url`  | no       | string | URL to a remote file containing the XSD schema to validate against.                   |
+| Input        | Required | Type   | Notes                                                                                 |
+|--------------|----------|--------|---------------------------------------------------------------------------------------|
+| `pattern`    | yes      | string | The file(s) to validate. The input expects a path to a single file or a glob pattern. |
+| `xsd-file`   | no       | string | Path to a local file containing the XSD schema to validate against.                   |
+| `xsd-url`    | no       | string | URL to a remote file containing the XSD schema to validate against.                   |
+| `show-in-pr` | no       | bool   | Annotate any errors from xmllint inline in PRs ? Defaults to `true`.                  |
 
 > [!NOTE]
 > If both an `xsd-file` and an `xsd-url` are passed, the `xsd-file` takes precedence.

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
     description: 'URL to a remote file containing the XSD schema to validate against.'
     required: false
     default: ''
+  show-in-pr:
+    description: 'Show any errors from xmllint inline in PRs ?'
+    required: false
 
 runs:
   using: "composite"
@@ -119,6 +122,12 @@ runs:
     - name: 'Install xmllint'
       shell: bash
       run: sudo apt-get -q install --no-install-recommends -y libxml2-utils > /dev/null
+
+    # Show XML violations inline in the file diff.
+    # @link https://github.com/marketplace/actions/xmllint-problem-matcher
+    - name: 'Enable showing XML issues inline'
+      if: ${{ inputs.show-in-pr != 'false' }}
+      uses: korelstar/xmllint-problem-matcher@v1
 
     - name: 'Validate for well-formedness'
       if: ${{ ! inputs.xsd-file && ! inputs.xsd-url }}


### PR DESCRIPTION
This commit adds a new input to allow for hooking into the GitHub annotations API.

This allows for flagging any violations flagged by `xmllint` in the code view of PRs. It also allows for the violations to be rendered in the "Annotations" fold-out in GH Actions job pages.

By default, the `show-in-pr` flag is set to `true`.

Includes tests.

Ref: https://github.com/korelstar/xmllint-problem-matcher

---

Please note that even though GH Action `input` meta data is supposed to allow for a "default" value, this doesn't appear to work correctly. Might be that it doesn't work for composite actions, might be that only string values are supported (though I tested that too and still had no luck), but either way, the fact that we can't rely on a meaningful default value is problematic.

In other words, to support this toggle flag properly, we can't use an `if: ${{ input.show-in-pr }}` check, as it won't behave as expected. Instead we need to explicitly check against a `false` value to safeguard the default behaviour (annotations = on) is respected.