### PR TITLE
Add a "debug" mode with more verbose output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,6 +198,22 @@ jobs:
             show-in-pr: somethingElse
             expected: "fail"
 
+          ####################################################
+          # Verbose vs non-verbose output.
+          ####################################################
+
+          # Re-run a few tests with verbosity on to allow for viewing the difference in the output.
+          # Safeguard that explicitly enabling/disabling the debug option doesn't break anything.
+          - name: "Debug off, valid XML"
+            pattern: tests/fixtures/valid-basic.xml
+            debug: false
+            expected: "success"
+
+          - name: "Debug on, invalid XML"
+            pattern: ./tests/*/some-valid-basic/*.xml
+            debug: true
+            expected: "fail"
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -211,6 +227,7 @@ jobs:
           xsd-file: ${{ matrix.xsd-file }}
           xsd-url: ${{ matrix.xsd-url }}
           show-in-pr: ${{ matrix.show-in-pr }}
+          debug: ${{ matrix.debug }}
 
       - name: "Check the result of a successful test against expectation"
         if: ${{ steps.xmllint-validate.outcome == 'success' }}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ GitHub Action to validate XML files for being well-formed and optionally validat
 | `xsd-file`   | no       | string | Path to a local file containing the XSD schema to validate against.                   |
 | `xsd-url`    | no       | string | URL to a remote file containing the XSD schema to validate against.                   |
 | `show-in-pr` | no       | bool   | Annotate any errors from xmllint inline in PRs ? Defaults to `true`.                  |
+| `debug`      | no       | bool   | Show verbose output to allow for debugging the action. Defaults to `false`.           |
 
 > [!NOTE]
 > If both an `xsd-file` and an `xsd-url` are passed, the `xsd-file` takes precedence.

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
   show-in-pr:
     description: 'Show any errors from xmllint inline in PRs ?'
     required: false
+  debug:
+    description: 'Whether to show verbose output for debugging the action'
+    required: false
 
 runs:
   using: "composite"
@@ -37,6 +40,18 @@ runs:
         # Validate pattern input.
         echo "::error title=XMLLint Validate::Missing required input 'pattern'. Please provide a path to a file or a glob pattern."
         exit 1
+
+    - name: 'Set debug mode'
+      env:
+        DEBUG_INPUT: ${{ inputs.debug }}
+      shell: bash
+      run: |
+        # Determine debug mode.
+        if [[ "${{ env.DEBUG_INPUT }}" == "true" ]]; then
+          echo "DEBUG=true" >> "$GITHUB_ENV"
+        else
+          echo "DEBUG=false" >> "$GITHUB_ENV"
+        fi
 
     - name: 'Validate local XSD file input'
       id: valid_xsdfile
@@ -99,7 +114,11 @@ runs:
             exit 1
           # Try to download it.
           else
-            wget -nc -nv "${{ env.XSD_URL }}" -O "${{ env.DOWNLOADED_XSD_FILE }}"
+            if [[ "${{ env.DEBUG }}" == "false" ]]; then
+              wget -nc -nv "${{ env.XSD_URL }}" -O "${{ env.DOWNLOADED_XSD_FILE }}"
+            else
+              wget -nc "${{ env.XSD_URL }}" -O "${{ env.DOWNLOADED_XSD_FILE }}"
+            fi
             if [[ -f "${{ env.DOWNLOADED_XSD_FILE }}" && -s "${{ env.DOWNLOADED_XSD_FILE }}" ]]; then
               echo 'Download of the XSD file succesfull.'
               exit 0
@@ -117,17 +136,39 @@ runs:
     - name: 'Update the available packages list'
       continue-on-error: true
       shell: bash
-      run: sudo apt-get -q update > /dev/null
+      run: |
+        # Update package list.
+        if [[ "${{ env.DEBUG }}" == "false" ]]; then
+          sudo apt-get -q update > /dev/null
+        else
+          sudo apt-get update
+        fi
 
     - name: 'Install xmllint'
       shell: bash
-      run: sudo apt-get -q install --no-install-recommends -y libxml2-utils > /dev/null
+      run: |
+        # Install xmllint.
+        if [[ "${{ env.DEBUG }}" == "false" ]]; then
+          sudo apt-get -q install --no-install-recommends -y libxml2-utils > /dev/null
+        else
+          sudo apt-get install --no-install-recommends -y libxml2-utils
+          xmllint --version
+        fi
 
     # Show XML violations inline in the file diff.
     # @link https://github.com/marketplace/actions/xmllint-problem-matcher
     - name: 'Enable showing XML issues inline'
       if: ${{ inputs.show-in-pr != 'false' }}
       uses: korelstar/xmllint-problem-matcher@v1
+
+    - name: 'List files'
+      if: ${{ inputs.debug }}
+      env:
+        GLOB_PATTERN: ${{ inputs.pattern }}
+      shell: bash
+      run: |
+        # List files which will be examined.
+        ls -ah $GLOB_PATTERN
 
     - name: 'Validate for well-formedness'
       if: ${{ ! inputs.xsd-file && ! inputs.xsd-url }}


### PR DESCRIPTION
This commit adds a new input to allow for debugging the action runner by showing more verbose output, including showing the XMLLint version used and showing what files will be matched by a glob pattern.

By default, the `debug` flag is set to `false` (= "off").

Includes tests.

---

Please note that even though GH Action `input` meta data is supposed to allow for a "default" value, this doesn't appear to work correctly. Might be that it doesn't work for composite actions, might be that only string values are supported (though I tested that too and still had no luck), but either way, the fact that we can't rely on a meaningful default value is problematic.

In other words, to support this toggle flag properly, we can't use an `if: ${{ input.debug }}` check, as it won't behave as expected. Instead we need to explicitly check against a `true` value to safeguard that the debug mode is only "on" when explicitly requested.

Also take note that, as done in other commits, when steps now become multi-line to handle the new input option correctly, a comment is added on the first line of the multi-line instructions to make the output more readable/understandable.