### PR TITLE
GH Actions: validate XSD files used in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,29 @@ jobs:
     name: 'QA Markdown'
     uses: PHPCSStandards/.github/.github/workflows/reusable-remark.yml@main
 
+  # Validate the "valid" XSD files used in the tests.
+  validate-xsds:
+    name: 'Validate XSD files'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate XSD file [1]
+        uses: ./
+        with:
+          pattern: tests/fixtures/xsd-files/valid-local.xsd
+          xsd-url: https://www.w3.org/2012/04/XMLSchema.xsd
+
+      - name: Validate XSD file [2]
+        uses: ./
+        with:
+          pattern: docs/test-fixtures/valid-remote.xsd
+          xsd-url: https://www.w3.org/2012/04/XMLSchema.xsd
+
   test:
-    needs: yamllint
+    needs: [yamllint, validate-xsds]
 
     name: "${{ matrix.name }}"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Eat our own dog food by using this action to validate the "valid" XSD files used in the tests against the official schema.