### PR TITLE
Action: pin used action runner

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -159,7 +159,7 @@ runs:
     # @link https://github.com/marketplace/actions/xmllint-problem-matcher
     - name: 'Enable showing XML issues inline'
       if: ${{ inputs.show-in-pr != 'false' }}
-      uses: korelstar/xmllint-problem-matcher@v1
+      uses: korelstar/xmllint-problem-matcher@1bd292d642ddf3d369d02aaa8b262834d61198c0 # v1.2.0
 
     - name: 'List files'
       if: ${{ inputs.debug }}


### PR DESCRIPTION
In light of recent security breaches and supply attack via GH Actions, following the best practice of pinning any underlying action runner used seems prudent (even though this action doesn't use secrets).

The XMLLint Validate action only uses one other action, and a low risk one at that.

This commit pins that action to the 1.2.0 release of the action runner.

Refs:
* https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
* https://www.bleepingcomputer.com/news/security/supply-chain-attack-on-popular-github-action-exposes-ci-cd-secrets/
* https://www.bleepingcomputer.com/news/security/github-action-hack-likely-led-to-another-in-cascading-supply-chain-attack/
* https://github.com/reviewdog/reviewdog/issues/2079
* https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-github-action-cve-2025-30066