### PR TITLE
GH Actions: pin re-usable workflows too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,17 +15,17 @@ concurrency:
 jobs:
   yamllint:
     name: 'Lint Yaml'
-    uses: PHPCSStandards/.github/.github/workflows/reusable-yamllint.yml@main
+    uses: PHPCSStandards/.github/.github/workflows/reusable-yamllint.yml@9d51cbe2ff0bde5f7f5b2cf7608e9e13d593c6f2 # v1.0.0
     with:
       strict: true
 
   markdownlint:
     name: 'Lint Markdown'
-    uses: PHPCSStandards/.github/.github/workflows/reusable-markdownlint.yml@main
+    uses: PHPCSStandards/.github/.github/workflows/reusable-markdownlint.yml@9d51cbe2ff0bde5f7f5b2cf7608e9e13d593c6f2 # v1.0.0
 
   remark:
     name: 'QA Markdown'
-    uses: PHPCSStandards/.github/.github/workflows/reusable-remark.yml@main
+    uses: PHPCSStandards/.github/.github/workflows/reusable-remark.yml@9d51cbe2ff0bde5f7f5b2cf7608e9e13d593c6f2 # v1.0.0
 
   # Validate the "valid" XSD files used in the tests.
   validate-xsds:


### PR DESCRIPTION
Follow up on #18, which added commit hash pinning to all externally managed action runners, this commit now also adds this to the re-usable workflows managed in the `PHPCSStandards/.github` repository.