### PR TITLE
Dependabot: change the cronjob scheduled time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "cron"
-      cronjob: "10 22 5,20 * *" # At 22:10, every 5th and 20th day of the month.
+      cronjob: "23 1 5,20 * *" # At 01:23, every 5th and 20th day of the month.
     open-pull-requests-limit: 5
     commit-message:
       prefix: "GH Actions:"


### PR DESCRIPTION
On occasion, when Dependabot submits an update which involves the `action.yml` file, it is cause to do a new release.

As quite a number of other repos I manage _use_ this action, it feels like a good idea to trigger the Dependabot run for this repo a little earlier than the others, to ensure that if the run for this repo would be reason for a new release, the _dependent_ packages will straight away update to that new release.