### PR TITLE
Support recursive `**` glob patterns via globstar

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,6 +137,35 @@ jobs:
             expected: "fail"
 
           ####################################################
+          # Recursive glob patterns (`**` / globstar).
+          ####################################################
+
+          # Test that `**` matches files across directory levels (no XSD).
+          # The fixtures place valid files at depths 0, 1 and 2, so this only
+          # passes if `**` recurses; without globstar it would miss depths 0 and 2.
+          - name: "Test no XSD, recursive glob, valid XML files"
+            pattern: ./tests/fixtures/all-valid-recursive/**/*.xml
+            expected: success
+
+          # The only invalid file lives two levels deep. Without recursive
+          # globbing it would not be matched and the run would wrongly pass, so
+          # this guards that `**` actually reaches nested directories.
+          - name: "Test no XSD, recursive glob, invalid XML deep in tree"
+            pattern: ./tests/fixtures/some-valid-recursive/**/*.xml
+            expected: fail
+
+          # Same, but validating against a local XSD schema.
+          - name: "Test XSD file, recursive glob, valid XML + schema"
+            pattern: ./tests/fixtures/all-valid-recursive-xsd/**/*.xml
+            xsd-file: tests/fixtures/xsd-files/valid-local.xsd
+            expected: success
+
+          - name: "Test XSD file, recursive glob, invalid XML deep in tree"
+            pattern: ./tests/fixtures/some-valid-recursive-xsd/**/*.xml
+            xsd-file: tests/fixtures/xsd-files/valid-local.xsd
+            expected: fail
+
+          ####################################################
           # Validate against an (originally) remote XSD file.
           ####################################################
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,24 @@ jobs:
           pattern: "path/to/*/docs/*.xml"
 ```
 
+Recursive glob patterns using `**` are supported and match files across any number of directory levels.
+For example, `**/*.xml` validates every `.xml` file in the repository, while `**/phpunit.xml` validates a
+file with that name no matter how deeply it is nested:
+```yaml
+jobs:
+  test:
+    name: "XMLLint validate"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Validate all XML files in the repo
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "**/*.xml"
+```
+
 Validating XML files against a locally available XSD schema:
 ```yaml
 jobs:

--- a/action.yml
+++ b/action.yml
@@ -168,6 +168,8 @@ runs:
       shell: bash
       run: |
         # List files which will be examined.
+        # Enable `**` to match files across directory levels (recursive glob).
+        shopt -s globstar
         ls -ah $GLOB_PATTERN
 
     - name: 'Validate for well-formedness'
@@ -175,7 +177,10 @@ runs:
       env:
         GLOB_PATTERN: ${{ inputs.pattern }}
       shell: bash
-      run: xmllint --noout $GLOB_PATTERN
+      run: |
+        # Enable `**` to match files across directory levels (recursive glob).
+        shopt -s globstar
+        xmllint --noout $GLOB_PATTERN
 
     - name: 'Validate against local schema'
       if: ${{ inputs.xsd-file }}
@@ -183,14 +188,20 @@ runs:
         GLOB_PATTERN: ${{ inputs.pattern }}
         XSD_FILE: ${{ inputs.xsd-file }}
       shell: bash
-      run: xmllint --noout --schema "$XSD_FILE" $GLOB_PATTERN
+      run: |
+        # Enable `**` to match files across directory levels (recursive glob).
+        shopt -s globstar
+        xmllint --noout --schema "$XSD_FILE" $GLOB_PATTERN
 
     - name: 'Validate against downloaded remote schema'
       if: ${{ ! inputs.xsd-file && inputs.xsd-url }}
       env:
         GLOB_PATTERN: ${{ inputs.pattern }}
       shell: bash
-      run: xmllint --noout --schema ${{ env.DOWNLOADED_XSD_FILE }} $GLOB_PATTERN
+      run: |
+        # Enable `**` to match files across directory levels (recursive glob).
+        shopt -s globstar
+        xmllint --noout --schema ${{ env.DOWNLOADED_XSD_FILE }} $GLOB_PATTERN
 
     - name: 'Clean up downloaded file'
       if: ${{ ! inputs.xsd-file && inputs.xsd-url }}

--- a/tests/fixtures/all-valid-recursive-xsd/A-good.xml
+++ b/tests/fixtures/all-valid-recursive-xsd/A-good.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<toplevel title="Short">
+    <myelement>Valid.</myelement>
+</toplevel>

--- a/tests/fixtures/all-valid-recursive-xsd/deeply/nested/C-good.xml
+++ b/tests/fixtures/all-valid-recursive-xsd/deeply/nested/C-good.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<toplevel title="Short">
+    <myelement>Valid.</myelement>
+</toplevel>

--- a/tests/fixtures/all-valid-recursive-xsd/sub/B-good.xml
+++ b/tests/fixtures/all-valid-recursive-xsd/sub/B-good.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<toplevel title="Short">
+    <myelement>Valid.</myelement>
+</toplevel>

--- a/tests/fixtures/all-valid-recursive/A-good.xml
+++ b/tests/fixtures/all-valid-recursive/A-good.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<toplevel title="Ten chars"/>

--- a/tests/fixtures/all-valid-recursive/deeply/nested/C-good.xml
+++ b/tests/fixtures/all-valid-recursive/deeply/nested/C-good.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<toplevel title="Ten chars"/>

--- a/tests/fixtures/all-valid-recursive/sub/B-good.xml
+++ b/tests/fixtures/all-valid-recursive/sub/B-good.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<toplevel title="Ten chars"/>

--- a/tests/fixtures/some-valid-recursive-xsd/A-good.xml
+++ b/tests/fixtures/some-valid-recursive-xsd/A-good.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<toplevel title="Short">
+    <myelement>Valid.</myelement>
+</toplevel>

--- a/tests/fixtures/some-valid-recursive-xsd/deeply/nested/C-bad.xml
+++ b/tests/fixtures/some-valid-recursive-xsd/deeply/nested/C-bad.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<nottoplevel title="Short"/>

--- a/tests/fixtures/some-valid-recursive-xsd/sub/B-good.xml
+++ b/tests/fixtures/some-valid-recursive-xsd/sub/B-good.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<toplevel title="Short">
+    <myelement>Valid.</myelement>
+</toplevel>

--- a/tests/fixtures/some-valid-recursive/A-good.xml
+++ b/tests/fixtures/some-valid-recursive/A-good.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<toplevel title="Ten chars"/>

--- a/tests/fixtures/some-valid-recursive/deeply/nested/C-bad.xml
+++ b/tests/fixtures/some-valid-recursive/deeply/nested/C-bad.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<something>
+    <unmatched/>
+</else>

--- a/tests/fixtures/some-valid-recursive/sub/B-good.xml
+++ b/tests/fixtures/some-valid-recursive/sub/B-good.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<toplevel title="Ten chars"/>


### PR DESCRIPTION
## Issue

Fixes #41.

## Changes

The `pattern` input was expanded with unquoted bash pathname expansion without `shopt -s globstar`, so `**` collapsed to a single `*` and only matched one directory level. This made it impossible to validate a filename at arbitrary depth (e.g. `**/phpunit.xml`).

Enable `shopt -s globstar` in every step that expands `$GLOB_PATTERN` (List files, well-formedness, local schema, remote schema) so `**` matches across directory levels.

Add recursive-glob test fixtures (valid files at depths 0/1/2, plus a variant whose only invalid file sits two levels deep) and matrix entries covering both well-formedness and local-XSD validation. Document the feature in the README.